### PR TITLE
feat: apply optimism regolith changes

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -4,11 +4,10 @@
 
 - commit: `13ee9ab`
 - differences
-  - change predeployed contract address([17](https://github.com/wemixkanvas/go-ethereum/pull/17)).
-  - remove daisy chain([11](https://github.com/wemixkanvas/go-ethereum/pull/11)).
-  - enable tx pool sync by force([13](https://github.com/wemixkanvas/go-ethereum/pull/13)).
-- todo
-  - apply [regolith](https://github.com/ethereum-optimism/optimism/blob/develop/specs/network-upgrades.md#regolith) changes.
+  - change predeployed contract address [#17](https://github.com/wemixkanvas/go-ethereum/pull/17).
+  - remove daisy chain [#11](https://github.com/wemixkanvas/go-ethereum/pull/11).
+  - enable tx pool sync by force [#13](https://github.com/wemixkanvas/go-ethereum/pull/13).
+  - remove system tx related fields. (e.g, `IsSystemTx()`) [#29](https://github.com/wemixkanvas/go-ethereum/pull/29).
 
 ## scroll-geth
 

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -904,7 +904,6 @@ func (m callMsg) Value() *big.Int              { return m.CallMsg.Value }
 func (m callMsg) Data() []byte                 { return m.CallMsg.Data }
 func (m callMsg) AccessList() types.AccessList { return m.CallMsg.AccessList }
 
-func (m callMsg) IsSystemTx() bool                   { return false }
 func (m callMsg) IsDepositTx() bool                  { return false }
 func (m callMsg) Mint() *big.Int                     { return nil }
 func (m callMsg) RollupDataGas() types.RollupGasData { return types.RollupGasData{} }

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -215,9 +215,15 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 			receipt.TxHash = tx.Hash()
 			receipt.GasUsed = msgResult.UsedGas
 
+			nonce := tx.Nonce()
+			if msg.IsDepositTx() {
+				nonce = statedb.GetNonce(msg.From())
+				receipt.DepositNonce = &nonce
+			}
+
 			// If the transaction created a contract, store the creation address in the receipt.
 			if msg.To() == nil {
-				receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+				receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, nonce)
 			}
 
 			// Set the receipt logs and create the bloom filter.

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -679,6 +679,15 @@ type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
 	Logs              []*types.Log
+
+	// Remaining fields are declared to allow the receipt RLP to be parsed without errors.
+	// However, they must not be used as they may not be populated correctly due to multiple receipt formats
+	// being combined into a single list of optional fields which can be mistaken for each other.
+	// DepositNonce (*uint64) will be parsed into L1GasUsed
+	L1GasUsed  *big.Int `rlp:"optional"` // OVM legacy
+	L1GasPrice *big.Int `rlp:"optional"` // OVM legacy
+	L1Fee      *big.Int `rlp:"optional"` // OVM legacy
+	FeeScalar  string   `rlp:"optional"` // OVM legacy
 }
 
 // ReceiptLogs is a barebone version of ReceiptForStorage which only keeps

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/big"
 	"math/rand"
 	"os"
@@ -704,6 +705,7 @@ func TestReadLogs(t *testing.T) {
 	body := &types.Body{Transactions: types.Transactions{tx1, tx2}}
 
 	// Create the two receipts to manage afterwards
+	depositNonce := uint64(math.MaxUint64)
 	receipt1 := &types.Receipt{
 		Status:            types.ReceiptStatusFailed,
 		CumulativeGasUsed: 1,
@@ -714,6 +716,7 @@ func TestReadLogs(t *testing.T) {
 		TxHash:          tx1.Hash(),
 		ContractAddress: common.BytesToAddress([]byte{0x01, 0x11, 0x11}),
 		GasUsed:         111111,
+		DepositNonce:    &depositNonce,
 	}
 	receipt1.Bloom = types.CreateBloom(types.Receipts{receipt1})
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -138,9 +138,15 @@ func applyTransaction(msg types.Message, config *params.ChainConfig, gp *GasPool
 	receipt.TxHash = tx.Hash()
 	receipt.GasUsed = result.UsedGas
 
+	nonce := tx.Nonce()
+	if msg.IsDepositTx() {
+		nonce = statedb.GetNonce(msg.From())
+		receipt.DepositNonce = &nonce
+	}
+
 	// If the transaction created a contract, store the creation address in the receipt.
 	if msg.To() == nil {
-		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, tx.Nonce())
+		receipt.ContractAddress = crypto.CreateAddress(evm.TxContext.Origin, nonce)
 	}
 
 	// Set the receipt logs and create the bloom filter.

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -37,8 +37,6 @@ type DepositTx struct {
 	Value *big.Int
 	// gas limit
 	Gas uint64
-	// Field indicating if this transaction is exempt from the L2 gas limit.
-	IsSystemTransaction bool
 	// Normal Tx data
 	Data []byte
 }
@@ -46,14 +44,13 @@ type DepositTx struct {
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *DepositTx) copy() TxData {
 	cpy := &DepositTx{
-		SourceHash:          tx.SourceHash,
-		From:                tx.From,
-		To:                  copyAddressPtr(tx.To),
-		Mint:                nil,
-		Value:               new(big.Int),
-		Gas:                 tx.Gas,
-		IsSystemTransaction: tx.IsSystemTransaction,
-		Data:                common.CopyBytes(tx.Data),
+		SourceHash: tx.SourceHash,
+		From:       tx.From,
+		To:         copyAddressPtr(tx.To),
+		Mint:       nil,
+		Value:      new(big.Int),
+		Gas:        tx.Gas,
+		Data:       common.CopyBytes(tx.Data),
 	}
 	if tx.Mint != nil {
 		cpy.Mint = new(big.Int).Set(tx.Mint)
@@ -76,7 +73,6 @@ func (tx *DepositTx) gasPrice() *big.Int     { return new(big.Int) }
 func (tx *DepositTx) value() *big.Int        { return tx.Value }
 func (tx *DepositTx) nonce() uint64          { return 0 }
 func (tx *DepositTx) to() *common.Address    { return tx.To }
-func (tx *DepositTx) isSystemTx() bool       { return tx.IsSystemTransaction }
 
 func (tx *DepositTx) rawSignatureValues() (v, r, s *big.Int) {
 	return common.Big0, common.Big0, common.Big0

--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"math/big"
 	"reflect"
@@ -27,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -80,6 +82,42 @@ var (
 		},
 		Type: DynamicFeeTxType,
 	}
+	depositReceiptNoNonce = &Receipt{
+		Status:            ReceiptStatusFailed,
+		CumulativeGasUsed: 1,
+		Logs: []*Log{
+			{
+				Address: common.BytesToAddress([]byte{0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+			{
+				Address: common.BytesToAddress([]byte{0x01, 0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+		},
+		Type: DepositTxType,
+	}
+	nonce                   = uint64(1234)
+	depositReceiptWithNonce = &Receipt{
+		Status:            ReceiptStatusFailed,
+		CumulativeGasUsed: 1,
+		DepositNonce:      &nonce,
+		Logs: []*Log{
+			{
+				Address: common.BytesToAddress([]byte{0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+			{
+				Address: common.BytesToAddress([]byte{0x01, 0x11}),
+				Topics:  []common.Hash{common.HexToHash("dead"), common.HexToHash("beef")},
+				Data:    []byte{0x01, 0x00, 0xff},
+			},
+		},
+		Type: DepositTxType,
+	}
 )
 
 func TestDecodeEmptyTypedReceipt(t *testing.T) {
@@ -117,7 +155,12 @@ func TestDeriveFields(t *testing.T) {
 			Gas:      3,
 			GasPrice: big.NewInt(3),
 		}),
+		NewTx(&DepositTx{
+			Value: big.NewInt(3),
+			Gas:   4,
+		}),
 	}
+	depNonce := uint64(7)
 	// Create the corresponding receipts
 	receipts := Receipts{
 		&Receipt{
@@ -154,6 +197,25 @@ func TestDeriveFields(t *testing.T) {
 			ContractAddress: common.BytesToAddress([]byte{0x03, 0x33, 0x33}),
 			GasUsed:         3,
 		},
+		&Receipt{
+			Type:              DepositTxType,
+			PostState:         common.Hash{3}.Bytes(),
+			CumulativeGasUsed: 10,
+			Logs: []*Log{
+				{Address: common.BytesToAddress([]byte{0x33})},
+				{Address: common.BytesToAddress([]byte{0x03, 0x33})},
+			},
+			TxHash:          txs[3].Hash(),
+			ContractAddress: common.BytesToAddress([]byte{0x03, 0x33, 0x33}),
+			GasUsed:         4,
+			DepositNonce:    &depNonce,
+		},
+	}
+	nonces := []uint64{
+		txs[0].Nonce(),
+		txs[1].Nonce(),
+		txs[2].Nonce(),
+		*receipts[3].DepositNonce, // Deposit tx should use deposit nonce
 	}
 	// Clear all the computed fields and re-derive them
 	number := big.NewInt(1)
@@ -190,7 +252,7 @@ func TestDeriveFields(t *testing.T) {
 			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), (common.Address{}).String())
 		}
 		from, _ := Sender(signer, txs[i])
-		contractAddress := crypto.CreateAddress(from, txs[i].Nonce())
+		contractAddress := crypto.CreateAddress(from, nonces[i])
 		if txs[i].To() == nil && receipts[i].ContractAddress != contractAddress {
 			t.Errorf("receipts[%d].ContractAddress = %s, want %s", i, receipts[i].ContractAddress.String(), contractAddress.String())
 		}
@@ -342,6 +404,38 @@ func TestReceiptUnmarshalBinary(t *testing.T) {
 	}
 }
 
+func TestDepositReceiptUnchanged(t *testing.T) {
+	expectedRlp := common.FromHex("7EF90156A003000000000000000000000000000000000000000000000000000000000000000AB9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000F0D7940000000000000000000000000000000000000033C001D7940000000000000000000000000000000000000333C002")
+	// Deposit receipt with no nonce
+	receipt := &Receipt{
+		Type:              DepositTxType,
+		PostState:         common.Hash{3}.Bytes(),
+		CumulativeGasUsed: 10,
+		Logs: []*Log{
+			{Address: common.BytesToAddress([]byte{0x33}), Data: []byte{1}, Topics: []common.Hash{}},
+			{Address: common.BytesToAddress([]byte{0x03, 0x33}), Data: []byte{2}, Topics: []common.Hash{}},
+		},
+		TxHash:          common.Hash{},
+		ContractAddress: common.BytesToAddress([]byte{0x03, 0x33, 0x33}),
+		GasUsed:         4,
+	}
+
+	rlp, err := receipt.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, expectedRlp, rlp)
+
+	// Consensus values should be unchanged after reparsing
+	parsed := new(Receipt)
+	err = parsed.UnmarshalBinary(rlp)
+	require.NoError(t, err)
+	require.Equal(t, receipt.Status, parsed.Status)
+	require.Equal(t, receipt.CumulativeGasUsed, parsed.CumulativeGasUsed)
+	require.Equal(t, receipt.Bloom, parsed.Bloom)
+	require.EqualValues(t, receipt.Logs, parsed.Logs)
+	// And still shouldn't have a nonce
+	require.Nil(t, parsed.DepositNonce)
+}
+
 func clearComputedFieldsOnReceipts(t *testing.T, receipts Receipts) {
 	t.Helper()
 
@@ -379,4 +473,65 @@ func clearComputedFieldsOnLog(t *testing.T, log *Log) {
 	log.TxHash = common.Hash{}
 	log.TxIndex = math.MaxUint32
 	log.Index = math.MaxUint32
+}
+
+func TestRoundTripReceipt(t *testing.T) {
+	tests := []struct {
+		name string
+		rcpt *Receipt
+	}{
+		{name: "Legacy", rcpt: legacyReceipt},
+		{name: "AccessList", rcpt: accessListReceipt},
+		{name: "EIP1559", rcpt: eip1559Receipt},
+		{name: "DepositNoNonce", rcpt: depositReceiptNoNonce},
+		{name: "DepositWithNonce", rcpt: depositReceiptWithNonce},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := test.rcpt.MarshalBinary()
+			require.NoError(t, err)
+
+			d := &Receipt{}
+			err = d.UnmarshalBinary(data)
+			require.NoError(t, err)
+			require.Equal(t, test.rcpt, d)
+		})
+
+		t.Run(fmt.Sprintf("%sRejectExtraData", test.name), func(t *testing.T) {
+			data, err := test.rcpt.MarshalBinary()
+			require.NoError(t, err)
+			data = append(data, 1, 2, 3, 4)
+			d := &Receipt{}
+			err = d.UnmarshalBinary(data)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestRoundTripReceiptForStorage(t *testing.T) {
+	tests := []struct {
+		name string
+		rcpt *Receipt
+	}{
+		{name: "Legacy", rcpt: legacyReceipt},
+		{name: "AccessList", rcpt: accessListReceipt},
+		{name: "EIP1559", rcpt: eip1559Receipt},
+		{name: "DepositNoNonce", rcpt: depositReceiptNoNonce},
+		{name: "DepositWithNonce", rcpt: depositReceiptWithNonce},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := rlp.EncodeToBytes((*ReceiptForStorage)(test.rcpt))
+			require.NoError(t, err)
+
+			d := &ReceiptForStorage{}
+			err = rlp.DecodeBytes(data, d)
+			require.NoError(t, err)
+			// Only check the stored fields - the others are derived later
+			require.Equal(t, test.rcpt.Status, d.Status)
+			require.Equal(t, test.rcpt.CumulativeGasUsed, d.CumulativeGasUsed)
+			require.Equal(t, test.rcpt.Logs, d.Logs)
+			require.Equal(t, test.rcpt.DepositNonce, d.DepositNonce)
+		})
+	}
 }

--- a/core/types/transaction_marshalling_test.go
+++ b/core/types/transaction_marshalling_test.go
@@ -11,9 +11,8 @@ import (
 
 func TestTransactionUnmarshalJsonDeposit(t *testing.T) {
 	tx := NewTx(&DepositTx{
-		SourceHash:          common.HexToHash("0x1234"),
-		IsSystemTransaction: true,
-		Mint:                big.NewInt(34),
+		SourceHash: common.HexToHash("0x1234"),
+		Mint:       big.NewInt(34),
 	})
 	json, err := tx.MarshalJSON()
 	require.NoError(t, err, "Failed to marshal tx JSON")
@@ -32,36 +31,31 @@ func TestTransactionUnmarshalJSON(t *testing.T) {
 	}{
 		{
 			name:          "No gas",
-			json:          `{"type":"0x7e","nonce":null,"gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			json:          `{"type":"0x7e","nonce":null,"gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
 			expectedError: "missing required field 'gas'",
 		},
 		{
 			name:          "No value",
-			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
 			expectedError: "missing required field 'value'",
 		},
 		{
 			name:          "No input",
-			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
 			expectedError: "missing required field 'input'",
 		},
 		{
 			name:          "No from",
-			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
 			expectedError: "missing required field 'from'",
 		},
 		{
 			name:          "No sourceHash",
-			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"from":"0x0000000000000000000000000000000000000001","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+			json:          `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"from":"0x0000000000000000000000000000000000000001","hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
 			expectedError: "missing required field 'sourceHash'",
 		},
 		{
 			name: "No mint",
-			json: `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","isSystemTx":false,"hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
-			// Allowed
-		},
-		{
-			name: "No IsSystemTx",
 			json: `{"type":"0x7e","nonce":null,"gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
 			// Allowed
 		},

--- a/core/types/tx_access_list.go
+++ b/core/types/tx_access_list.go
@@ -105,7 +105,6 @@ func (tx *AccessListTx) gasFeeCap() *big.Int    { return tx.GasPrice }
 func (tx *AccessListTx) value() *big.Int        { return tx.Value }
 func (tx *AccessListTx) nonce() uint64          { return tx.Nonce }
 func (tx *AccessListTx) to() *common.Address    { return tx.To }
-func (tx *AccessListTx) isSystemTx() bool       { return false }
 
 func (tx *AccessListTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/core/types/tx_dynamic_fee.go
+++ b/core/types/tx_dynamic_fee.go
@@ -93,7 +93,6 @@ func (tx *DynamicFeeTx) gasPrice() *big.Int     { return tx.GasFeeCap }
 func (tx *DynamicFeeTx) value() *big.Int        { return tx.Value }
 func (tx *DynamicFeeTx) nonce() uint64          { return tx.Nonce }
 func (tx *DynamicFeeTx) to() *common.Address    { return tx.To }
-func (tx *DynamicFeeTx) isSystemTx() bool       { return false }
 
 func (tx *DynamicFeeTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/core/types/tx_legacy.go
+++ b/core/types/tx_legacy.go
@@ -102,7 +102,6 @@ func (tx *LegacyTx) gasFeeCap() *big.Int    { return tx.GasPrice }
 func (tx *LegacyTx) value() *big.Int        { return tx.Value }
 func (tx *LegacyTx) nonce() uint64          { return tx.Nonce }
 func (tx *LegacyTx) to() *common.Address    { return tx.To }
-func (tx *LegacyTx) isSystemTx() bool       { return false }
 
 func (tx *LegacyTx) rawSignatureValues() (v, r, s *big.Int) {
 	return tx.V, tx.R, tx.S

--- a/eth/api.go
+++ b/eth/api.go
@@ -320,7 +320,7 @@ func (api *DebugAPI) GetBadBlocks(ctx context.Context) ([]*BadBlockArgs, error) 
 		} else {
 			blockRlp = fmt.Sprintf("%#x", rlpBytes)
 		}
-		if blockJSON, err = ethapi.RPCMarshalBlock(block, true, true, api.eth.APIBackend.ChainConfig()); err != nil {
+		if blockJSON, err = ethapi.RPCMarshalBlock(ctx, block, true, true, api.eth.APIBackend); err != nil {
 			blockJSON = map[string]interface{}{"error": err.Error()}
 		}
 		results = append(results, &BadBlockArgs{

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1239,7 +1239,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
-func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *params.ChainConfig) (map[string]interface{}, error) {
+func RPCMarshalBlock(ctx context.Context, block *types.Block, inclTx bool, fullTx bool, backend Backend) (map[string]interface{}, error) {
 	fields := RPCMarshalHeader(block.Header())
 	fields["size"] = hexutil.Uint64(block.Size())
 
@@ -1249,7 +1249,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 		}
 		if fullTx {
 			formatTx = func(tx *types.Transaction) (interface{}, error) {
-				return newRPCTransactionFromBlockHash(block, tx.Hash(), config), nil
+				return newRPCTransactionFromBlockHash(ctx, block, tx.Hash(), backend), nil
 			}
 		}
 		txs := block.Transactions()
@@ -1285,7 +1285,7 @@ func (s *BlockChainAPI) rpcMarshalHeader(ctx context.Context, header *types.Head
 // rpcMarshalBlock uses the generalized output filler, then adds the total difficulty field, which requires
 // a `BlockchainAPI`.
 func (s *BlockChainAPI) rpcMarshalBlock(ctx context.Context, b *types.Block, inclTx bool, fullTx bool) (map[string]interface{}, error) {
-	fields, err := RPCMarshalBlock(b, inclTx, fullTx, s.b.ChainConfig())
+	fields, err := RPCMarshalBlock(ctx, b, inclTx, fullTx, s.b)
 	if err != nil {
 		return nil, err
 	}
@@ -1320,36 +1320,13 @@ type RPCTransaction struct {
 	// deposit-tx only
 	SourceHash *common.Hash `json:"sourceHash,omitempty"`
 	Mint       *hexutil.Big `json:"mint,omitempty"`
-	IsSystemTx *bool        `json:"isSystemTx,omitempty"`
 }
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
-func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int, config *params.ChainConfig) *RPCTransaction {
+func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int, config *params.ChainConfig, receipt *types.Receipt) *RPCTransaction {
 	signer := types.MakeSigner(config, new(big.Int).SetUint64(blockNumber))
 	from, _ := types.Sender(signer, tx)
-	if tx.Type() == types.DepositTxType {
-		srcHash := tx.SourceHash()
-		isSystemTx := tx.IsSystemTx()
-		result := &RPCTransaction{
-			Type:       hexutil.Uint64(tx.Type()),
-			From:       from,
-			Gas:        hexutil.Uint64(tx.Gas()),
-			Hash:       tx.Hash(),
-			Input:      hexutil.Bytes(tx.Data()),
-			To:         tx.To(),
-			Value:      (*hexutil.Big)(tx.Value()),
-			Mint:       (*hexutil.Big)(tx.Mint()),
-			SourceHash: &srcHash,
-			IsSystemTx: &isSystemTx,
-		}
-		if blockHash != (common.Hash{}) {
-			result.BlockHash = &blockHash
-			result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
-			result.TransactionIndex = (*hexutil.Uint64)(&index)
-		}
-		return result
-	}
 	v, r, s := tx.RawSignatureValues()
 	result := &RPCTransaction{
 		Type:     hexutil.Uint64(tx.Type()),
@@ -1371,6 +1348,13 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.TransactionIndex = (*hexutil.Uint64)(&index)
 	}
 	switch tx.Type() {
+	case types.DepositTxType:
+		srcHash := tx.SourceHash()
+		result.SourceHash = &srcHash
+		result.Mint = (*hexutil.Big)(tx.Mint())
+		if receipt != nil && receipt.DepositNonce != nil {
+			result.Nonce = hexutil.Uint64(*receipt.DepositNonce)
+		}
 	case types.LegacyTxType:
 		// if a legacy transaction has an EIP-155 chain id, include it explicitly
 		if id := tx.ChainId(); id.Sign() != 0 {
@@ -1406,16 +1390,32 @@ func NewRPCPendingTransaction(tx *types.Transaction, current *types.Header, conf
 		baseFee = misc.CalcBaseFee(config, current)
 		blockNumber = current.Number.Uint64()
 	}
-	return newRPCTransaction(tx, common.Hash{}, blockNumber, 0, baseFee, config)
+	return newRPCTransaction(tx, common.Hash{}, blockNumber, 0, baseFee, config, nil)
 }
 
 // newRPCTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
-func newRPCTransactionFromBlockIndex(b *types.Block, index uint64, config *params.ChainConfig) *RPCTransaction {
+func newRPCTransactionFromBlockIndex(ctx context.Context, b *types.Block, index uint64, backend Backend) *RPCTransaction {
 	txs := b.Transactions()
 	if index >= uint64(len(txs)) {
 		return nil
 	}
-	return newRPCTransaction(txs[index], b.Hash(), b.NumberU64(), index, b.BaseFee(), config)
+	tx := txs[index]
+	rcpt := depositTxReceipt(ctx, b.Hash(), index, backend, tx)
+	return newRPCTransaction(tx, b.Hash(), b.NumberU64(), index, b.BaseFee(), backend.ChainConfig(), rcpt)
+}
+
+func depositTxReceipt(ctx context.Context, blockHash common.Hash, index uint64, backend Backend, tx *types.Transaction) *types.Receipt {
+	if tx.Type() != types.DepositTxType {
+		return nil
+	}
+	receipts, err := backend.GetReceipts(ctx, blockHash)
+	if err != nil {
+		return nil
+	}
+	if index >= uint64(len(receipts)) {
+		return nil
+	}
+	return receipts[index]
 }
 
 // newRPCRawTransactionFromBlockIndex returns the bytes of a transaction given a block and a transaction index.
@@ -1429,10 +1429,10 @@ func newRPCRawTransactionFromBlockIndex(b *types.Block, index uint64) hexutil.By
 }
 
 // newRPCTransactionFromBlockHash returns a transaction that will serialize to the RPC representation.
-func newRPCTransactionFromBlockHash(b *types.Block, hash common.Hash, config *params.ChainConfig) *RPCTransaction {
+func newRPCTransactionFromBlockHash(ctx context.Context, b *types.Block, hash common.Hash, backend Backend) *RPCTransaction {
 	for idx, tx := range b.Transactions() {
 		if tx.Hash() == hash {
-			return newRPCTransactionFromBlockIndex(b, uint64(idx), config)
+			return newRPCTransactionFromBlockIndex(ctx, b, uint64(idx), backend)
 		}
 	}
 	return nil
@@ -1567,7 +1567,7 @@ func (s *TransactionAPI) GetBlockTransactionCountByHash(ctx context.Context, blo
 // GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
 func (s *TransactionAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, index hexutil.Uint) *RPCTransaction {
 	if block, _ := s.b.BlockByNumber(ctx, blockNr); block != nil {
-		return newRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig())
+		return newRPCTransactionFromBlockIndex(ctx, block, uint64(index), s.b)
 	}
 	return nil
 }
@@ -1575,7 +1575,7 @@ func (s *TransactionAPI) GetTransactionByBlockNumberAndIndex(ctx context.Context
 // GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
 func (s *TransactionAPI) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, index hexutil.Uint) *RPCTransaction {
 	if block, _ := s.b.BlockByHash(ctx, blockHash); block != nil {
-		return newRPCTransactionFromBlockIndex(block, uint64(index), s.b.ChainConfig())
+		return newRPCTransactionFromBlockIndex(ctx, block, uint64(index), s.b)
 	}
 	return nil
 }
@@ -1627,7 +1627,8 @@ func (s *TransactionAPI) GetTransactionByHash(ctx context.Context, hash common.H
 		if err != nil {
 			return nil, err
 		}
-		return newRPCTransaction(tx, blockHash, blockNumber, index, header.BaseFee, s.b.ChainConfig()), nil
+		rcpt := depositTxReceipt(ctx, blockHash, index, s.b, tx)
+		return newRPCTransaction(tx, blockHash, blockNumber, index, header.BaseFee, s.b.ChainConfig(), rcpt), nil
 	}
 	// No finalized transaction, try to retrieve it from the pool
 	if tx := s.b.GetPoolTransaction(hash); tx != nil {
@@ -1691,11 +1692,15 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 		"logsBloom":         receipt.Bloom,
 		"type":              hexutil.Uint(tx.Type()),
 	}
-	if s.b.ChainConfig().Kanvas != nil && !tx.IsDepositTx() {
-		fields["l1GasPrice"] = (*hexutil.Big)(receipt.L1GasPrice)
-		fields["l1GasUsed"] = (*hexutil.Big)(receipt.L1GasUsed)
-		fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)
-		fields["l1FeeScalar"] = receipt.FeeScalar.String()
+	if s.b.ChainConfig().Kanvas != nil {
+		if tx.IsDepositTx() {
+			fields["depositNonce"] = hexutil.Uint64(*receipt.DepositNonce)
+		} else {
+			fields["l1GasPrice"] = (*hexutil.Big)(receipt.L1GasPrice)
+			fields["l1GasUsed"] = (*hexutil.Big)(receipt.L1GasUsed)
+			fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)
+			fields["l1FeeScalar"] = receipt.FeeScalar.String()
+		}
 	}
 	// Assign the effective gas price paid
 	if !s.b.ChainConfig().IsLondon(bigblock) {


### PR DESCRIPTION
- Optimism regolith disables system tx. This means gas account logic is the same as user deposit tx.
- use depositNonce to compute contract address.
- set depositNonce as nonce in transaction receipt.

See https://github.com/ethereum-optimism/optimism/blob/develop/specs/network-upgrades.md#post-bedrock-network-upgrades